### PR TITLE
Uncommented the guts of testOverlap function

### DIFF
--- a/box2D/collision/shapes/B2Shape.hx
+++ b/box2D/collision/shapes/B2Shape.hx
@@ -121,9 +121,9 @@ class B2Shape
 	public static function testOverlap(shape1:B2Shape, transform1:B2Transform, shape2:B2Shape, transform2:B2Transform):Bool
 	{
 		// This seems to greatly improve performance on some platforms, without negative effects
-		return true;
+		//return true;
 		
-		/*var input:B2DistanceInput = new B2DistanceInput ();
+		var input:B2DistanceInput = new B2DistanceInput ();
 		input.proxyA = new B2DistanceProxy ();
 		input.proxyA.set(shape1);
 		input.proxyB = new B2DistanceProxy();
@@ -135,7 +135,7 @@ class B2Shape
 		simplexCache.count = 0;
 		var output:B2DistanceOutput = new B2DistanceOutput();
 		B2Distance.distance(output, simplexCache, input);
-		return output.distance  < 10.0 * B2Math.MIN_VALUE;*/
+		return output.distance  < 10.0 * B2Math.MIN_VALUE;
 	}
 	
 	//--------------- Internals Below -------------------


### PR DESCRIPTION
I was having troubles when it came to detecting collisions with sensors. Collisions were being called when the AABBs were overlapping instead of the fixtures themselves.
