### PR TITLE
Change instances of Std.is with Std.isOfType

### DIFF
--- a/box2D/collision/shapes/B2CircleShape.hx
+++ b/box2D/collision/shapes/B2CircleShape.hx
@@ -45,7 +45,7 @@ class B2CircleShape extends B2Shape
 	override public function set(other:B2Shape):Void 
 	{
 		super.set(other);
-		if (Std.is (other, B2CircleShape))
+		if (Std.isOfType (other, B2CircleShape))
 		{
 			var other2:B2CircleShape = cast (other, B2CircleShape);
 			m_p.setV(other2.m_p);

--- a/box2D/collision/shapes/B2PolygonShape.hx
+++ b/box2D/collision/shapes/B2PolygonShape.hx
@@ -48,7 +48,7 @@ class B2PolygonShape extends B2Shape
 	public override function set(other:B2Shape):Void 
 	{
 		super.set(other);
-		if (Std.is (other, B2PolygonShape))
+		if (Std.isOfType (other, B2PolygonShape))
 		{
 			var other2:B2PolygonShape = cast (other, B2PolygonShape);
 			m_centroid.setV(other2.m_centroid);

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "tags": [ "physics", "flash", "cpp" ],
   "description": "Box2D is a tremendously popular physics engine for most platforms.",
-  "version": "1.2.3",
-  "releasenote": "Added TestBed sample, better B2ShapeType, platform fixes",
+  "version": "1.2.4",
+  "releasenote": "Replace instances of Std.is with Std.isOfType",
   "contributors": [ "singmajesty" ],
   "dependencies": {}
 }


### PR DESCRIPTION
I changed all instances of Std.is to Std.isOfType to avoid deprecation. Let me know if I need to change anything else.